### PR TITLE
Added alt-f4.blog to the actions

### DIFF
--- a/src/actions/check_alt4_blog.rs
+++ b/src/actions/check_alt4_blog.rs
@@ -1,0 +1,80 @@
+//! Check alt-f4 alternative friday facts
+//!
+//! This polls https://alt-f4.blog/ at a regular interval. If there is a
+//! new post available, it will be broadcasted to the IRC client.
+
+use crate::data::Client;
+use regex::Regex;
+use std::time::Duration;
+
+pub fn spawn(client: Client, channel_name: String) {
+    tokio::spawn(async move {
+        let mut last_facts = None;
+        while client.running() {
+            sleep().await;
+            let facts = match get_last_facts_post().await {
+                Ok(v) => v,
+                Err(e) => {
+                    eprintln!("Cannot poll factorio version: {:?}", e);
+                    continue;
+                }
+            };
+            if last_facts.is_some() && last_facts != Some(facts.clone()) {
+                let topic = match client.find_channel(&channel_name) {
+                    Some(channel) => channel.topic(),
+                    None => {
+                        eprintln!("Tried to notify of a new alt-f4 blog, but could not find channel {:?}", channel_name);
+                        continue;
+                    }
+                };
+                let mut split: Vec<String> =
+                    topic.split('|').map(|s| String::from(s.trim())).collect();
+
+                if split.len() < 4 {
+                    eprintln!("Invalid channel topic, expected at least 4 parts");
+                    eprintln!("Topic is now: {:?}", topic);
+                } else {
+                    let url = format!("https://alt-f4.blog/ALTF4-4/");
+                    split[3] = format!("{}: {}", url, facts);
+
+                    client.set_channel_topic(&channel_name, split.join(" | "));
+                    client.send_to_channel(
+                        &channel_name,
+                        format!("New Al-f4 facts: {} {}", facts, url),
+                    );
+                }
+            }
+            last_facts = Some(facts);
+        }
+    });
+}
+
+async fn sleep() {
+    tokio::time::delay_for(Duration::from_secs(10)).await;
+}
+
+#[tokio::test]
+async fn load_facts() {
+    let facts = get_last_facts_post().await.expect("Could not load version");
+    assert!(
+        !facts.is_empty() && facts.chars().all(|c| c == '.' || c.is_numeric()),
+        "Facts version is invalid, got: {:?}",
+        facts
+    );
+}
+
+async fn get_last_facts_post() -> Result<String, String> {
+    let response = reqwest::get("https://alt-f4.blog/")
+        .await
+        .map_err(|e| e.to_string())?
+        .text()
+        .await
+        .map_err(|e| e.to_string())?;
+
+    let regex = Regex::new(r#"Alt\-F4 \#([0-9\.]+)([^<]+)"#).map_err(|e| e.to_string())?;
+    if let Some(capture) = regex.captures_iter(&response).next() {
+        Ok(capture[0].to_owned())
+    } else {
+        Err(String::from("Could not find last alt facts post"))
+    }
+}

--- a/src/actions/check_alt4_blog.rs
+++ b/src/actions/check_alt4_blog.rs
@@ -23,7 +23,10 @@ pub fn spawn(client: Client, channel_name: String) {
                 let topic = match client.find_channel(&channel_name) {
                     Some(channel) => channel.topic(),
                     None => {
-                        eprintln!("Tried to notify of a new alt-f4 blog, but could not find channel {:?}", channel_name);
+                        eprintln!(
+                            "Tried to notify of a new alt-f4 blog, but could not find channel {:?}",
+                            channel_name
+                        );
                         continue;
                     }
                 };
@@ -55,9 +58,11 @@ async fn sleep() {
 
 #[tokio::test]
 async fn load_facts() {
-    let facts = get_last_facts_post().await.expect("Could not find last alt facts post");
+    let facts = get_last_facts_post()
+        .await
+        .expect("Could not find last alt facts post");
     assert!(
-        !facts.is_empty() ,
+        !facts.is_empty(),
         "Facts version is invalid, got: {:?}",
         facts
     );

--- a/src/actions/check_alt4_blog.rs
+++ b/src/actions/check_alt4_blog.rs
@@ -37,7 +37,7 @@ pub fn spawn(client: Client, channel_name: String) {
                     let url = format!("https://alt-f4.blog/ALTF4-4/");
                     split[3] = format!("{}: {}", url, facts);
 
-                    client.set_channel_topic(&channel_name, split.join(" | "));
+                    // client.set_channel_topic(&channel_name, split.join(" | "));
                     client.send_to_channel(
                         &channel_name,
                         format!("New Al-f4 facts: {} {}", facts, url),
@@ -55,9 +55,9 @@ async fn sleep() {
 
 #[tokio::test]
 async fn load_facts() {
-    let facts = get_last_facts_post().await.expect("Could not load version");
+    let facts = get_last_facts_post().await.expect("Could not find last alt facts post");
     assert!(
-        !facts.is_empty() && facts.chars().all(|c| c == '.' || c.is_numeric()),
+        !facts.is_empty() ,
         "Facts version is invalid, got: {:?}",
         facts
     );

--- a/src/actions/check_alt4_blog.rs
+++ b/src/actions/check_alt4_blog.rs
@@ -37,7 +37,7 @@ pub fn spawn(client: Client, channel_name: String) {
                     eprintln!("Invalid channel topic, expected at least 4 parts");
                     eprintln!("Topic is now: {:?}", topic);
                 } else {
-                    let url = format!("https://alt-f4.blog/ALTF4-4/");
+                    let url = format!("https://alt-f4.blog/ALTF4-{}/", facts);
                     split[3] = format!("{}: {}", url, facts);
 
                     // client.set_channel_topic(&channel_name, split.join(" | "));

--- a/src/actions/mod.rs
+++ b/src/actions/mod.rs
@@ -1,5 +1,6 @@
 mod autojoin;
 mod check_factorio_friday_facts;
+mod check_alt4_blog;
 mod check_factorio_version;
 mod commands;
 mod multiplayer_info;
@@ -10,6 +11,7 @@ use crate::data::{Client, Message};
 pub async fn on_start(client: Client) -> Result<(), String> {
     if let Some(factorio_channel) = client.server_config().factorio_channel {
         check_factorio_version::spawn(client.clone(), factorio_channel.clone());
+        check_alt4_blog::spawn(client.clone(), factorio_channel.clone());
         check_factorio_friday_facts::spawn(client, factorio_channel);
     }
     commands::start();

--- a/src/actions/mod.rs
+++ b/src/actions/mod.rs
@@ -1,6 +1,6 @@
 mod autojoin;
-mod check_factorio_friday_facts;
 mod check_alt4_blog;
+mod check_factorio_friday_facts;
 mod check_factorio_version;
 mod commands;
 mod multiplayer_info;


### PR DESCRIPTION
Added alt-f4.blog to the actions:

// set_channel_topic is commented out for the moment.
Topic 4 will be replaced by, example:
A | B | C | https://alt-f4.blog/ALTF4-4/: Alt-F4 #4 - Designing Blueprints

Test however is a little bit awkward. Maybe you come up with a better test.